### PR TITLE
feat: support auto named member. like: bigfishSdk/router.js

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,10 @@ function findDeclareSourceNode(ast: any, name: string): INodeValue | undefined {
     return findDeclareSourceNode(ast, init.name);
   } else if (init.type === 'ObjectExpression') {
     // find member like: x.routerRedux = require$$0;
-    const members = esquery(ast, `ExpressionStatement [object.name=${name}][computed=false]`);
+    const members = esquery(
+      ast,
+      `AssignmentExpression > MemberExpression > [object.name=${name}][computed=false]`,
+    );
     return {
       ...init,
       members,
@@ -117,7 +120,7 @@ export default function namedExport(options: IOptions = { sourceMap: false }) {
         return null;
       }
 
-      // if(id.indexOf("node_modules/_@alipay_umi-plugin-bigfish@2.8.1-1@@alipay/umi-plugin-bigfish/lib/plugins/bigfishSdk/router.js") !== -1) {
+      // if (id.indexOf('ules/draft-js/lib/DraftEditorCompositionHandler.js') !== -1) {
       //   console.log(code);
       // }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "noUnusedParameters": true,
     "noUnusedLocals": true,
     "noImplicitAny": true,
-    "target": "es6",
+    "target": "es5",
     "lib": ["dom", "es7"]
   },
   "exclude": ["node_modules", "lib", "es"]


### PR DESCRIPTION
支持作为 member 被 exports 的 case. 类似
```js
x.Link = function LinkWrapper(props) {
  if (typeof props.to !== 'undefined') {
    return React.createElement(Link, props);
  }

  if (process.env.NODE_ENV === 'development') {
    /*eslint no-console: "off"*/
    console.warn('<Link /> 需要设置属性 "to"', props);
  }

  return React.createElement('a', props);
};

module.exports = x;
```
打包会在末尾自动增加 named exports，让 rollup 不报 `MISSING_EXPORT`
```
 // common js 自动添加的
var router = x;
export { router as __moduleExports };  

// 这个包自动添加的
var Link_Akpmx = router.Link
export { Link_Akpmx as Link }
```
